### PR TITLE
options: add skip metadata refresh

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -43,6 +43,15 @@ pub struct ExporterOptions {
 }
 
 impl ExporterOptions {
+    /// Enable metadata refresh?
+    pub(crate) fn enable_metadata_refresh(&self) -> bool {
+        let cluster_subsystems = Self::nodes_subsystems();
+
+        self.exporter_metrics_enabled
+            .iter()
+            .any(|(k, v)| cluster_subsystems.contains(&k.as_str()) && *v)
+    }
+
     /// Check if metric is enabled
     pub fn is_metric_enabled(&self, subsystem: &'static str) -> bool {
         self.exporter_metrics_enabled.contains_key(subsystem)


### PR DESCRIPTION
Change-Id: Ic7fb23de404de4c05f146ae92ac1697fdbd55f46

Adding skip metadata refresh when none of the `/_nodes` subsystems is enabled