### PR TITLE
collection: skip metrics only on first occurrence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ $ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_ur
  - Metric collection is decoupled from serving `/metrics` page
  - Skips zero/empty metrics (controlled with flag `exporter_allow_zero_metrics`)
  - Elasticsearch "millis" converted to seconds
- - Gauges everywhere
  - All time based metrics are converted as f64 seconds, keywords `millis` replaced with `seconds`
  - Added `_bytes` and `_seconds` postfix
  - Preserves metrics tree namespace up to last leaf


### PR DESCRIPTION
Change-Id: Iec63382ef9ce75d72b4d679775d12e5f42a7dcfe

When a skip zero metrics option is enabled and metric is zero it will be skipped, however, this means metric will never reset to zero.
This change skips metrics only for the first occurrence. 