### PR TITLE
metrics: add info metric to /_cat/aliases

### DIFF
--- a/src/metrics/_cat/aliases.rs
+++ b/src/metrics/_cat/aliases.rs
@@ -1,4 +1,7 @@
 use elasticsearch::cat::CatAliasesParts;
+use serde_json::Map as SerdeMap;
+
+use super::responses::CatResponse;
 
 pub(crate) const SUBSYSTEM: &'static str = "cat_aliases";
 
@@ -15,7 +18,37 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
         .send()
         .await?;
 
-    Ok(metric::from_values(response.json::<Vec<Value>>().await?))
+    let values = response
+        .json::<CatResponse>()
+        .await?
+        .into_values(inject_cat_aliases_info);
+
+    Ok(metric::from_values(values))
+}
+
+fn inject_cat_aliases_info(map: &mut SerdeMap<String, Value>) {
+    let is_system_index: bool = map
+        .get("index")
+        .map(|index| index.as_str().map(|s| s.starts_with(".")).unwrap_or(false))
+        .unwrap_or(false);
+
+    if is_system_index {
+        map.clear();
+    } else {
+        let _ = map.insert("info".into(), Value::from(1));
+    }
 }
 
 crate::poll_metrics!();
+
+#[tokio::test]
+async fn test_cat_aliases() {
+    let cat: CatResponse = serde_json::from_str(include_str!("../../tests/files/cat_aliases.json"))
+        .expect("valid json");
+
+    let got = cat.into_values(inject_cat_aliases_info);
+
+    assert_eq!(got.len(), 52);
+
+    assert_eq!(got[0]["info"], 1);
+}

--- a/src/tests/files/cat_aliases.json
+++ b/src/tests/files/cat_aliases.json
@@ -1,0 +1,434 @@
+[
+  {
+    "alias": "nl-tore-index",
+    "filter": "-",
+    "index": "nl-nl-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "nl-tore-index-es7",
+    "filter": "-",
+    "index": "nl-nl-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-es-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-es-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.01",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.01",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "uk-tore-index",
+    "filter": "-",
+    "index": "uk-en-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "uk-tore-index-es7",
+    "filter": "-",
+    "index": "uk-en-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-it-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-it-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-lt-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-lt-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.04",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.04",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "pl-tore-index",
+    "filter": "-",
+    "index": "pl-pl-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "pl-tore-index-es7",
+    "filter": "-",
+    "index": "pl-pl-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-de-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-de-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": ".kibana",
+    "filter": "-",
+    "index": ".kibana_1",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.04",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.04",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-nl-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-nl-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.07",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.07",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "ltdw-tore-index",
+    "filter": "-",
+    "index": "ltdw-lt-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "ltdw-tore-index-es7",
+    "filter": "-",
+    "index": "ltdw-lt-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": ".kibana_task_manager",
+    "filter": "-",
+    "index": ".kibana_task_manager_1",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "lt-tore-index",
+    "filter": "-",
+    "index": "lt-lt-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "lt-tore-index-es7",
+    "filter": "-",
+    "index": "lt-lt-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.10",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.10",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-wr-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-wr-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_old",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_old",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.07",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.07",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "us-tore-index",
+    "filter": "-",
+    "index": "us-en-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "us-tore-index-es7",
+    "filter": "-",
+    "index": "us-en-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-en-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-en-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "de-tore-index",
+    "filter": "-",
+    "index": "de-de-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "de-tore-index-es7",
+    "filter": "-",
+    "index": "de-de-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "es-tore-index",
+    "filter": "-",
+    "index": "es-es-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "es-tore-index-es7",
+    "filter": "-",
+    "index": "es-es-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "tz-tore-index",
+    "filter": "-",
+    "index": "tz-tz-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "tz-tore-index-es7",
+    "filter": "-",
+    "index": "tz-tz-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.10",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2019.10",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "dedw-tore-index",
+    "filter": "-",
+    "index": "dedw-de-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "dedw-tore-index-es7",
+    "filter": "-",
+    "index": "dedw-de-tore-index_20201203082900",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.01",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  },
+  {
+    "alias": "wr-tore-index-es7",
+    "filter": "-",
+    "index": "wr-tore-index_20201120062041_2020.01",
+    "is_write_index": "-",
+    "routing.index": "-",
+    "routing.searth": "-"
+  }
+]


### PR DESCRIPTION
Change-Id: If5278190aabfa43b6411a40bb44615bf320b1253

Inject dummy info label to /_cat/aliases response to generate aliases info metrics

> foobar_build_info (for a pseudo-metric that provides metadata about the running binary) https://prometheus.io/docs/practices/naming/

Possibilities: https://www.robustperception.io/exposing-the-software-version-to-prometheus

This change will allow to expose aliases as info metrics

```
# HELP elasticsearch_cat_aliases_info info
# TYPE elasticsearch_cat_aliases_info gauge
elasticsearch_cat_aliases_info{alias="ggw-awkj",cluster="mine",inwwx="cz-czobs-awkj_20201203082900"} 1
elasticsearch_cat_aliases_info{alias="ggw-awkj-es7",cluster="mine",inwwx="cz-czobs-awkj_20201203082900"} 1
elasticsearch_cat_aliases_info{alias="ww-awkj",cluster="mine",inwwx="ww-wwobs-awkj_20201203082900"} 1
elasticsearch_cat_aliases_info{alias="ww-awkj-es7",cluster="mine",inwwx="ww-wwobs-awkj_20201203082900"} 1
```