### PR TITLE
metadata: implement indices refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +223,7 @@ name = "elasticsearch_exporter"
 version = "0.17.0"
 dependencies = [
  "byte-unit",
+ "chrono",
  "clap",
  "elasticsearch",
  "humantime 2.1.0",
@@ -616,6 +629,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_derive = "1.0.124"
 serde_qs = "0.8.3"
 byte-unit = "4.0.9"
 oorandom = "11.1.3"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dependencies.hyper]
 version = "0.14.4"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -41,7 +41,7 @@ impl fmt::Display for SimpleError {
 
 impl StdError for SimpleError {}
 
-const HASH_MAP_STR_FORMAT: &'static str = "cat_indices=id,pri,rep&cat_nodes=heap.percent,jdk";
+const HASH_MAP_STR_FORMAT: &str = "cat_indices=id,pri,rep&cat_nodes=heap.percent,jdk";
 
 #[derive(Clap, Clone, Debug)]
 pub struct Opts {
@@ -161,10 +161,10 @@ impl FromStr for HashMapDuration {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let mut map = ExporterPollIntervals::new();
 
-        let parts = input.trim().split("&").into_iter().collect::<Vec<&str>>();
+        let parts = input.trim().split('&').collect::<Vec<&str>>();
 
-        for part in parts.into_iter() {
-            match part.split_once("=") {
+        for part in parts {
+            match part.split_once('=') {
                 Some((key, value)) => match value.parse::<humantime::Duration>() {
                     Ok(time) => {
                         let _ = map.insert(key.to_string(), *time);
@@ -198,13 +198,13 @@ impl FromStr for HashMapVec {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let mut map = CollectionLabels::new();
 
-        let parts = input.trim().split("&").into_iter().collect::<Vec<&str>>();
+        let parts = input.trim().split('&').collect::<Vec<&str>>();
 
-        for part in parts.into_iter() {
-            match part.split_once("=") {
+        for part in parts {
+            match part.split_once('=') {
                 Some((key, value)) => {
                     let labels = value
-                        .split(",")
+                        .split(',')
                         .map(|value| value.to_string())
                         .collect::<Vec<String>>();
 

--- a/src/bin/elasticsearch_exporter.rs
+++ b/src/bin/elasticsearch_exporter.rs
@@ -43,7 +43,7 @@ async fn serve_req(req: Request<Body>, options: String) -> Result<Response<Body>
 
     let response = match path {
         "/health" | "/healthy" | "/healthz" => build_response(StatusCode::OK, Body::from("Ok")),
-        "/" => build_response(StatusCode::OK, Body::from(options.to_string())),
+        "/" => build_response(StatusCode::OK, Body::from(options)),
 
         "/metrics" => {
             let encoder = TextEncoder::new();

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -156,14 +156,14 @@ impl Collection {
 
         metrics.retain(|metric| match metric.metric_type() {
             MetricType::Label(label) => {
-                if self.include_labels.contains(&metric.string_ref()) {
+                if self.include_labels.contains(metric.string_ref()) {
                     let _ = labels.insert(metric.key().to_string(), label.to_string());
                 }
                 false
             }
             _ => {
-                !self.skip_labels.contains(&metric.string_ref())
-                    && !self.skip_metrics.contains(&metric.string_ref())
+                !self.skip_labels.contains(metric.string_ref())
+                    && !self.skip_metrics.contains(metric.string_ref())
             }
         });
 
@@ -173,7 +173,7 @@ impl Collection {
             match metric.metric_type() {
                 MetricType::Switch(value) => {
                     if let Err(e) =
-                        self.insert_gauge(&metric.key(), *value as i64, &labels, None, false)
+                        self.insert_gauge(metric.key(), *value as i64, &labels, None, false)
                     {
                         error!("SWITCH insert_gauge {:?} err {}", metric, e);
                         return Err(e);
@@ -186,20 +186,20 @@ impl Collection {
                     } else {
                         Some("_bytes")
                     };
-                    if let Err(e) = self.insert_gauge(&metric.key(), *value, &labels, postfix, true)
+                    if let Err(e) = self.insert_gauge(metric.key(), *value, &labels, postfix, true)
                     {
                         error!("BYTES insert_gauge {:?} err {}", metric, e);
                         return Err(e);
                     }
                 }
                 MetricType::GaugeF(value) => {
-                    if let Err(e) = self.insert_fgauge(&metric.key(), *value, &labels, None, true) {
+                    if let Err(e) = self.insert_fgauge(metric.key(), *value, &labels, None, true) {
                         error!("GAUGEF insert_fgauge {:?} err {}", metric, e);
                         return Err(e);
                     }
                 }
                 MetricType::Gauge(value) => {
-                    if let Err(e) = self.insert_gauge(&metric.key(), *value, &labels, None, true) {
+                    if let Err(e) = self.insert_gauge(metric.key(), *value, &labels, None, true) {
                         error!("GAUGE insert_gauge {:?} err {}", metric, e);
                         return Err(e);
                     }
@@ -232,15 +232,20 @@ impl Collection {
     }
 }
 
-#[test]
-fn test_float_is_zero() {
-    let num: f64 = 0.000000000000000000000000000000000000000000000000000000000000000000001;
-    assert!(num != 0.0);
-    assert!(num.is_normal());
+#[cfg(test)]
+mod tests {
 
-    let zero: f64 = 0.0;
-    assert!(!zero.is_normal());
+    #[test]
+    fn test_float_is_zero() {
+        let num: f64 = 0.000000000000000000000000000000000000000000000000000000000000000000001;
+        assert!(num != 0.0);
+        assert!(num.is_normal());
 
-    let negative: f64 = -0.000000000000000000000000000000000000000000000000000000000000000000001;
-    assert!(negative.is_normal());
+        let zero: f64 = 0.0;
+        assert!(!zero.is_normal());
+
+        let negative: f64 =
+            -0.000000000000000000000000000000000000000000000000000000000000000000001;
+        assert!(negative.is_normal());
+    }
 }

--- a/src/metadata/index.rs
+++ b/src/metadata/index.rs
@@ -1,0 +1,127 @@
+use elasticsearch::cat::CatIndicesParts;
+use elasticsearch::params::Time;
+use elasticsearch::{Elasticsearch, Error};
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+
+use crate::{exporter_metrics::SUBSYSTEM_REQ_HISTOGRAM, Exporter};
+
+pub(crate) type IndexToMetadata = RwLock<IndexDataMap>;
+
+pub(crate) type IndexDataMap = HashMap<String, IndexMetadata>;
+
+/// Current Index metadata
+#[derive(Debug, Clone)]
+pub struct IndexMetadata {
+    pub last_hearbeat: chrono::DateTime<chrono::Utc>,
+}
+
+impl Default for IndexMetadata {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IndexMetadata {
+    /// Initialize Index metadata
+    pub fn new() -> Self {
+        Self {
+            last_hearbeat: chrono::Utc::now(),
+        }
+    }
+
+    /// Set heartbeat
+    pub fn reset_heartbeat(&mut self) -> &mut Self {
+        self.last_hearbeat = chrono::Utc::now();
+        self
+    }
+}
+
+/// Current Index metadata
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct CatIndexData {
+    /// index name
+    pub(crate) index: String,
+}
+
+pub(crate) async fn build(client: &Elasticsearch) -> Result<IndexDataMap, Error> {
+    info!("Elasticsearch: fetching indices metadata");
+    let index_data_map = client
+        .cat()
+        .indices(CatIndicesParts::None)
+        .format("json")
+        .h(&["index"])
+        // Return local information, do not retrieve the state from master node (default: false)
+        .local(true)
+        .time(Time::Ms)
+        .send()
+        .await?
+        .json::<Vec<CatIndexData>>()
+        .await?
+        .into_iter()
+        .map(|value| (value.index, IndexMetadata::new()))
+        .collect();
+
+    Ok(index_data_map)
+}
+
+#[inline]
+fn update_map(old: &mut IndexDataMap, new: IndexDataMap) {
+    for (key, new_metadata) in new {
+        let _ = old.entry(key).or_insert(new_metadata).reset_heartbeat();
+    }
+}
+
+#[allow(unused)]
+pub(crate) async fn poll(exporter: Exporter) {
+    let start = tokio::time::Instant::now();
+
+    let mut interval =
+        tokio::time::interval_at(start, exporter.options().exporter_metadata_refresh_interval);
+
+    loop {
+        let _ = interval.tick().await;
+
+        let timer = SUBSYSTEM_REQ_HISTOGRAM
+            .with_label_values(&["/_cat/indices", exporter.cluster_name()])
+            .start_timer();
+
+        match build(exporter.client()).await {
+            Ok(new_metadata) => {
+                update_map(&mut *exporter.index_metadata().write().await, new_metadata)
+            }
+            Err(e) => {
+                error!("poll metadata metrics err {}", e);
+            }
+        }
+
+        timer.observe_duration();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_map() {
+        let index_data: Vec<CatIndexData> =
+            serde_json::from_str(include_str!("../tests/files/metadata_cat_indices.json"))
+                .expect("valid json");
+
+        let mut old = index_data
+            .into_iter()
+            .map(|value| (value.index, IndexMetadata::new()))
+            .collect::<IndexDataMap>();
+
+        let key = "not_items_20210803115035";
+        let last_hearbeat = old.get(key).unwrap().last_hearbeat;
+
+        let new = old.clone();
+
+        update_map(&mut old, new);
+
+        // Check that heartbeat is updated to the latest value
+        assert_ne!(last_hearbeat, old.get(key).unwrap().last_hearbeat);
+    }
+}

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -3,7 +3,9 @@ use elasticsearch::{Elasticsearch, Error};
 use serde_json::Value;
 
 pub(crate) mod node_data;
-pub(crate) use node_data::{build, poll, IdToMetadata, NodeData};
+pub(crate) use node_data::{IdToMetadata, NodeData};
+pub(crate) mod index;
+pub(crate) use index::IndexToMetadata;
 
 pub(crate) async fn cluster_name(client: &Elasticsearch) -> Result<String, Error> {
     info!("Elasticsearch: fetching cluster_name");

--- a/src/metric/metric_type.rs
+++ b/src/metric/metric_type.rs
@@ -42,7 +42,7 @@ impl<'s> TryFrom<RawMetric<'s>> for MetricType {
                 value
                     .as_str()
                     .map(|n| n.parse::<i64>())
-                    .ok_or(unknown())?
+                    .ok_or_else(unknown)?
                     .map_err(|e| MetricError::from_parse_int(e, Some(value.clone())))
             }
         };
@@ -55,7 +55,7 @@ impl<'s> TryFrom<RawMetric<'s>> for MetricType {
                     .as_str()
                     // .replace is handling string percent notation, e.g.: "3.44%"
                     .map(|n| n.replace("%", "").parse::<f64>())
-                    .ok_or(unknown())?
+                    .ok_or_else(unknown)?
                     .map_err(|e| MetricError::from_parse_float(e, Some(value.clone())))
             }
         };
@@ -131,7 +131,7 @@ impl<'s> TryFrom<RawMetric<'s>> for MetricType {
             "data" => match parse_i64() {
                 Ok(number) => Ok(MetricType::Gauge(number)),
                 Err(_) => Ok(MetricType::Label(
-                    value.as_str().ok_or(unknown())?.to_owned(),
+                    value.as_str().ok_or_else(unknown)?.to_owned(),
                 )),
             },
 
@@ -173,7 +173,7 @@ impl<'s> TryFrom<RawMetric<'s>> for MetricType {
             | "ip" | "prirep" | "id" | "status" | "at" | "for" | "details" | "reason" | "port"
             | "attr" | "field" | "shard" | "index" | "name" | "type" | "version"
             | "description" => Ok(MetricType::Label(
-                value.as_str().ok_or(unknown())?.to_owned(),
+                value.as_str().ok_or_else(unknown)?.to_owned(),
             )),
             _ => {
                 if cfg!(debug_assertions) {
@@ -187,7 +187,7 @@ impl<'s> TryFrom<RawMetric<'s>> for MetricType {
                 }
 
                 Ok(MetricType::Label(
-                    value.as_str().ok_or(unknown())?.to_owned(),
+                    value.as_str().ok_or_else(unknown)?.to_owned(),
                 ))
             }
         }

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -44,14 +44,14 @@ impl<'s> TryFrom<RawMetric<'s>> for Metric {
 
         let underscore_index = key.rfind('_').unwrap_or(0);
 
-        let shift = if key.contains("_") { 1 } else { 0 };
+        let shift = if key.contains('_') { 1 } else { 0 };
 
         let last = key
             .get(underscore_index + shift..key.len())
             .unwrap_or("UNKNOWN");
 
-        debug_assert!(!last.contains("_"));
-        debug_assert!(!last.contains("."));
+        debug_assert!(!last.contains('_'));
+        debug_assert!(!last.contains('.'));
 
         let metric_type = MetricType::try_from((last, metric.1))?;
 
@@ -59,28 +59,33 @@ impl<'s> TryFrom<RawMetric<'s>> for Metric {
     }
 }
 
-#[test]
-fn test_try_from_raw_metric() {
-    use std::time::Duration;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let metric = "elasticsearch.test_metric.total".to_string();
-    let raw: RawMetric = (&metric, &Value::from("2299291"));
+    #[test]
+    fn test_try_from_raw_metric() {
+        use std::time::Duration;
 
-    let m = Metric::try_from(raw);
-    assert!(m.is_ok());
-    let m = m.unwrap();
-    assert_eq!(&m.key(), &"elasticsearch_test_metric_total");
-    assert_eq!(m.metric_type(), &MetricType::Gauge(2299291));
+        let metric = "elasticsearch.test_metric.total".to_string();
+        let raw: RawMetric = (&metric, &Value::from("2299291"));
 
-    let metric = "elasticsearch.test_metric.time".to_string();
-    let raw: RawMetric = (&metric, &Value::from("10"));
+        let m = Metric::try_from(raw);
+        assert!(m.is_ok());
+        let m = m.unwrap();
+        assert_eq!(&m.key(), &"elasticsearch_test_metric_total");
+        assert_eq!(m.metric_type(), &MetricType::Gauge(2299291));
 
-    let m = Metric::try_from(raw);
-    assert!(m.is_ok());
-    let m = m.unwrap();
-    assert_eq!(&m.key(), &"elasticsearch_test_metric_time");
-    assert_eq!(
-        m.metric_type(),
-        &MetricType::Time(Duration::from_millis(10))
-    );
+        let metric = "elasticsearch.test_metric.time".to_string();
+        let raw: RawMetric = (&metric, &Value::from("10"));
+
+        let m = Metric::try_from(raw);
+        assert!(m.is_ok());
+        let m = m.unwrap();
+        assert_eq!(&m.key(), &"elasticsearch_test_metric_time");
+        assert_eq!(
+            m.metric_type(),
+            &MetricType::Time(Duration::from_millis(10))
+        );
+    }
 }

--- a/src/metrics/_cat/aliases.rs
+++ b/src/metrics/_cat/aliases.rs
@@ -3,7 +3,7 @@ use serde_json::Map as SerdeMap;
 
 use super::responses::CatResponse;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_aliases";
+pub(crate) const SUBSYSTEM: &str = "cat_aliases";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter
@@ -29,7 +29,7 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
 fn inject_cat_aliases_info(map: &mut SerdeMap<String, Value>) {
     let is_system_index: bool = map
         .get("index")
-        .map(|index| index.as_str().map(|s| s.starts_with(".")).unwrap_or(false))
+        .map(|index| index.as_str().map(|s| s.starts_with('.')).unwrap_or(false))
         .unwrap_or(false);
 
     if is_system_index {

--- a/src/metrics/_cat/allocation.rs
+++ b/src/metrics/_cat/allocation.rs
@@ -1,7 +1,7 @@
 use elasticsearch::cat::CatAllocationParts;
 use elasticsearch::params::Bytes;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_allocation";
+pub(crate) const SUBSYSTEM: &str = "cat_allocation";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/fielddata.rs
+++ b/src/metrics/_cat/fielddata.rs
@@ -1,7 +1,7 @@
 use elasticsearch::cat::CatFielddataParts;
 use elasticsearch::params::Bytes;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_fielddata";
+pub(crate) const SUBSYSTEM: &str = "cat_fielddata";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/health.rs
+++ b/src/metrics/_cat/health.rs
@@ -1,6 +1,6 @@
 use elasticsearch::params::Time;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_health";
+pub(crate) const SUBSYSTEM: &str = "cat_health";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/indices.rs
+++ b/src/metrics/_cat/indices.rs
@@ -1,7 +1,7 @@
 use elasticsearch::cat::CatIndicesParts;
 use elasticsearch::params::{Bytes, Time};
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_indices";
+pub(crate) const SUBSYSTEM: &str = "cat_indices";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/nodeattrs.rs
+++ b/src/metrics/_cat/nodeattrs.rs
@@ -1,4 +1,4 @@
-pub(crate) const SUBSYSTEM: &'static str = "cat_nodeattrs";
+pub(crate) const SUBSYSTEM: &str = "cat_nodeattrs";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/nodes.rs
+++ b/src/metrics/_cat/nodes.rs
@@ -1,6 +1,6 @@
 use elasticsearch::params::Bytes;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_nodes";
+pub(crate) const SUBSYSTEM: &str = "cat_nodes";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/pending_tasks.rs
+++ b/src/metrics/_cat/pending_tasks.rs
@@ -1,6 +1,6 @@
 use elasticsearch::params::Time;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_pending_tasks";
+pub(crate) const SUBSYSTEM: &str = "cat_pending_tasks";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/plugins.rs
+++ b/src/metrics/_cat/plugins.rs
@@ -1,4 +1,4 @@
-pub(crate) const SUBSYSTEM: &'static str = "cat_plugins";
+pub(crate) const SUBSYSTEM: &str = "cat_plugins";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/recovery.rs
+++ b/src/metrics/_cat/recovery.rs
@@ -1,7 +1,7 @@
 use elasticsearch::cat::CatRecoveryParts;
 use elasticsearch::params::{Bytes, Time};
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_recovery";
+pub(crate) const SUBSYSTEM: &str = "cat_recovery";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/repositories.rs
+++ b/src/metrics/_cat/repositories.rs
@@ -1,4 +1,4 @@
-pub(crate) const SUBSYSTEM: &'static str = "cat_repositories";
+pub(crate) const SUBSYSTEM: &str = "cat_repositories";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/segments.rs
+++ b/src/metrics/_cat/segments.rs
@@ -1,7 +1,7 @@
 use elasticsearch::cat::CatSegmentsParts;
 use elasticsearch::params::Bytes;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_segments";
+pub(crate) const SUBSYSTEM: &str = "cat_segments";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/shards.rs
+++ b/src/metrics/_cat/shards.rs
@@ -3,7 +3,7 @@ use elasticsearch::params::{Bytes, Time};
 
 use super::responses::CatResponse;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_shards";
+pub(crate) const SUBSYSTEM: &str = "cat_shards";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/templates.rs
+++ b/src/metrics/_cat/templates.rs
@@ -1,6 +1,6 @@
 use elasticsearch::cat::CatTemplatesParts;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_templates";
+pub(crate) const SUBSYSTEM: &str = "cat_templates";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/thread_pool.rs
+++ b/src/metrics/_cat/thread_pool.rs
@@ -1,6 +1,6 @@
 use elasticsearch::cat::CatThreadPoolParts;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_thread_pool";
+pub(crate) const SUBSYSTEM: &str = "cat_thread_pool";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cat/transforms.rs
+++ b/src/metrics/_cat/transforms.rs
@@ -1,7 +1,7 @@
 use elasticsearch::cat::CatTransformsParts;
 use elasticsearch::params::Time;
 
-pub(crate) const SUBSYSTEM: &'static str = "cat_transforms";
+pub(crate) const SUBSYSTEM: &str = "cat_transforms";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cluster/health.rs
+++ b/src/metrics/_cluster/health.rs
@@ -1,6 +1,6 @@
 use elasticsearch::cluster::ClusterHealthParts;
 
-pub(crate) const SUBSYSTEM: &'static str = "cluster_health";
+pub(crate) const SUBSYSTEM: &str = "cluster_health";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_cluster/stats.rs
+++ b/src/metrics/_cluster/stats.rs
@@ -1,6 +1,6 @@
 use elasticsearch::cluster::ClusterStatsParts;
 
-pub(crate) const SUBSYSTEM: &'static str = "cluster_stats";
+pub(crate) const SUBSYSTEM: &str = "cluster_stats";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter

--- a/src/metrics/_nodes/info.rs
+++ b/src/metrics/_nodes/info.rs
@@ -2,7 +2,7 @@ use elasticsearch::nodes::NodesInfoParts;
 
 use super::responses::NodesResponse;
 
-pub(crate) const SUBSYSTEM: &'static str = "nodes_info";
+pub(crate) const SUBSYSTEM: &str = "nodes_info";
 
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
@@ -19,13 +19,13 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
     let values = response
         .json::<NodesResponse>()
         .await?
-        .into_values(exporter.metadata(), REMOVE_KEYS)
+        .into_values(exporter.nodes_metadata(), REMOVE_KEYS)
         .await;
 
     Ok(metric::from_values(values))
 }
 
-const REMOVE_KEYS: &[&'static str] = &[
+const REMOVE_KEYS: &[&str] = &[
     "aggregations",
     "timestamp",
     "plugins",

--- a/src/metrics/_nodes/responses/mod.rs
+++ b/src/metrics/_nodes/responses/mod.rs
@@ -26,7 +26,7 @@ impl NodesResponse {
         // Inject node label
         for (node_id, mut data) in self.nodes.drain() {
             if let Some(node_metadata) = metadata_read.get(&node_id) {
-                inject_label(&mut data, &node_metadata, keys_to_remove);
+                inject_label(&mut data, node_metadata, keys_to_remove);
 
                 values.push(data);
             }

--- a/src/metrics/_nodes/stats.rs
+++ b/src/metrics/_nodes/stats.rs
@@ -2,7 +2,7 @@ use elasticsearch::nodes::NodesStatsParts;
 
 use super::responses::NodesResponse;
 
-pub(crate) const SUBSYSTEM: &'static str = "nodes_stats";
+pub(crate) const SUBSYSTEM: &str = "nodes_stats";
 
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
@@ -20,7 +20,7 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
     let values = response
         .json::<NodesResponse>()
         .await?
-        .into_values(&exporter.metadata(), REMOVE_KEYS)
+        .into_values(exporter.nodes_metadata(), REMOVE_KEYS)
         .await;
 
     Ok(metric::from_values(values))
@@ -28,7 +28,7 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
 
 // NOTE:
 // enabling adaptive_selection exposes metrics in nanoseconds, e.g.: "avg_response_time_ns": 196669342
-const REMOVE_KEYS: &[&'static str] = &[
+const REMOVE_KEYS: &[&str] = &[
     "timestamp",
     "attributes",
     "cgroup",

--- a/src/metrics/_nodes/usage.rs
+++ b/src/metrics/_nodes/usage.rs
@@ -2,7 +2,7 @@ use elasticsearch::nodes::NodesUsageParts;
 
 use super::responses::NodesResponse;
 
-pub(crate) const SUBSYSTEM: &'static str = "nodes_usage";
+pub(crate) const SUBSYSTEM: &str = "nodes_usage";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter
@@ -16,13 +16,13 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
     let values = response
         .json::<NodesResponse>()
         .await?
-        .into_values(exporter.metadata(), REMOVE_KEYS)
+        .into_values(exporter.nodes_metadata(), REMOVE_KEYS)
         .await;
 
     Ok(metric::from_values(values))
 }
 
-const REMOVE_KEYS: &[&'static str] = &["since", "timestamp"];
+const REMOVE_KEYS: &[&str] = &["since", "timestamp"];
 
 crate::poll_metrics!();
 

--- a/src/metrics/_stats/_all.rs
+++ b/src/metrics/_stats/_all.rs
@@ -2,7 +2,7 @@ use elasticsearch::indices::IndicesStatsParts;
 
 use super::responses::StatsResponse;
 
-pub(crate) const SUBSYSTEM: &'static str = "stats";
+pub(crate) const SUBSYSTEM: &str = "stats";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let response = exporter
@@ -23,7 +23,7 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
     Ok(metric::from_values(values))
 }
 
-const REMOVE_KEYS: &[&'static str] = &["uuid"];
+const REMOVE_KEYS: &[&str] = &["uuid"];
 
 crate::poll_metrics!();
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -62,7 +62,7 @@ impl ExporterOptions {
         self.elasticsearch_query_fields
             .get(subsystem)
             .map(|params| params.iter().map(AsRef::as_ref).collect::<Vec<&str>>())
-            .unwrap_or(Vec::new())
+            .unwrap_or_default()
     }
 
     /// Path parameters for subsystems
@@ -70,15 +70,15 @@ impl ExporterOptions {
         self.elasticsearch_path_parameters
             .get(subsystem)
             .map(|params| params.iter().map(AsRef::as_ref).collect::<Vec<&str>>())
-            .unwrap_or(Vec::new())
+            .unwrap_or_default()
     }
 
     /// Get timeout for subsystem or fallback to global
     pub fn timeout_for_subsystem(&self, subsystem: &'static str) -> Duration {
-        self.elasticsearch_subsystem_timeouts
+        *self
+            .elasticsearch_subsystem_timeouts
             .get(subsystem)
             .unwrap_or(&self.elasticsearch_global_timeout)
-            .clone()
     }
 
     /// /_cat subsystems
@@ -128,10 +128,10 @@ impl ExporterOptions {
 }
 
 fn switch_to_string(output: &mut String, field: &'static str, switches: &ExporterMetricsSwitch) {
-    output.push_str("\n");
+    output.push('\n');
     output.push_str(&format!("{}:", field));
     for (k, v) in switches.iter() {
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(" - {}: {}", k, v));
     }
 }
@@ -141,10 +141,10 @@ fn collection_labels_to_string(
     field: &'static str,
     labels: &CollectionLabels,
 ) {
-    output.push_str("\n");
+    output.push('\n');
     output.push_str(&format!("{}:", field));
     for (k, v) in labels.iter() {
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(" - {}: {}", k, v.join(",")));
     }
 }
@@ -154,19 +154,19 @@ fn poll_duration_to_string(
     field: &'static str,
     labels: &ExporterPollIntervals,
 ) {
-    output.push_str("\n");
+    output.push('\n');
     output.push_str(&format!("{}:", field));
     for (k, v) in labels.iter() {
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(" - {}: {:?}", k, v));
     }
 }
 
 fn vec_to_string(output: &mut String, field: &'static str, fields: &[&'static str]) {
-    output.push_str("\n");
+    output.push('\n');
     output.push_str(&format!("{}:", field));
     for field in fields.iter() {
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(" - {}", field));
     }
 }
@@ -175,34 +175,34 @@ impl fmt::Display for ExporterOptions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut output = String::from("Vinted Elasticsearch exporter");
 
-        output.push_str("\n");
+        output.push('\n');
         vec_to_string(
             &mut output,
             "Available /_cat subsystems",
-            &Self::cat_subsystems(),
+            Self::cat_subsystems(),
         );
         vec_to_string(
             &mut output,
             "Available /_cluster subsystems",
-            &Self::cluster_subsystems(),
+            Self::cluster_subsystems(),
         );
         vec_to_string(
             &mut output,
             "Available /_nodes subsystems",
-            &Self::nodes_subsystems(),
+            Self::nodes_subsystems(),
         );
         vec_to_string(
             &mut output,
             "Available /_stats subsystems",
-            &Self::stats_subsystems(),
+            Self::stats_subsystems(),
         );
-        output.push_str("\n");
+        output.push('\n');
 
-        output.push_str("\n");
+        output.push('\n');
         output.push_str("Exporter settings:");
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!("elasticsearch_url: {}", self.elasticsearch_url));
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(
             "elasticsearch_global_timeout: {:?}",
             self.elasticsearch_global_timeout
@@ -243,7 +243,7 @@ impl fmt::Display for ExporterOptions {
         );
 
         // Exporter
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(
             "exporter_poll_default_interval: {:?}",
             self.exporter_poll_default_interval
@@ -255,7 +255,7 @@ impl fmt::Display for ExporterOptions {
             &self.exporter_poll_intervals,
         );
 
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(
             "exporter_skip_zero_metrics: {:?}",
             self.exporter_skip_zero_metrics
@@ -267,13 +267,13 @@ impl fmt::Display for ExporterOptions {
             &self.exporter_metrics_enabled,
         );
 
-        output.push_str("\n");
+        output.push('\n');
         output.push_str(&format!(
             "exporter_metadata_refresh_interval: {:?}",
             self.exporter_metadata_refresh_interval
         ));
 
-        output.push_str("\n");
+        output.push('\n');
         write!(f, "{}", output)
     }
 }

--- a/src/reserved.rs
+++ b/src/reserved.rs
@@ -1,2 +1,2 @@
 /// Injected namespaced label for cluster version
-pub const INJECT_CLUSTER_VERSION: &'static str = "vin_cluster_version";
+pub const INJECT_CLUSTER_VERSION: &str = "vin_cluster_version";

--- a/src/tests/files/metadata_cat_indices.json
+++ b/src/tests/files/metadata_cat_indices.json
@@ -1,0 +1,17 @@
+[
+  {
+    "creation.date": "1625646307247",
+    "creation.date.string": "2021-07-07T08:25:07.247Z",
+    "index": "forum_20210707082506"
+  },
+  {
+    "creation.date": "1628070074743",
+    "creation.date.string": "2021-08-04T09:41:14.743Z",
+    "index": "other_20210804094113"
+  },
+  {
+    "creation.date": "1627991441604",
+    "creation.date.string": "2021-08-03T11:50:41.604Z",
+    "index": "not_items_20210803115035"
+  }
+]


### PR DESCRIPTION
Fetch `/_cat/indices` endpoint to record the time when was the last time index was present. Heartbeat of a index will help to distinguish deleted indices which in turn will enable to delete stale metrics. 