### PR TITLE
cluster_health: add explicit cluster_status label

### DIFF
--- a/src/metrics/_cluster/health.rs
+++ b/src/metrics/_cluster/health.rs
@@ -1,3 +1,7 @@
+use prometheus::IntGaugeVec;
+use serde_json::Map as SerdeMap;
+
+use super::responses::CluserHealthResponse;
 use elasticsearch::cluster::ClusterHealthParts;
 
 pub(crate) const SUBSYSTEM: &str = "cluster_health";
@@ -13,7 +17,67 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
         .send()
         .await?;
 
-    Ok(metric::from_value(response.json::<Value>().await?))
+    let values = response
+        .json::<CluserHealthResponse>()
+        .await?
+        .into_value(inject_cluster_health);
+
+    Ok(metric::from_value(values))
+}
+
+lazy_static! {
+    static ref CLUSTER_STATUS: IntGaugeVec = register_int_gauge_vec!(
+        "elasticsearch_cluster_health_status",
+        "Whether all primary and replica shards are allocated.",
+        &["cluster", "color"]
+    )
+    .expect("valid prometheus metric");
+}
+
+const COLORS: [&str; 3] = ["red", "green", "yellow"];
+
+// elasticsearch_cluster_health_cluster_status{cluster="some",status="green"} 1
+fn inject_cluster_health(map: &mut SerdeMap<String, Value>) {
+    let cluster_status: String = map
+        .get("status")
+        .map(|v| v.as_str())
+        .flatten()
+        .map(ToOwned::to_owned)
+        .unwrap_or("red".into());
+
+    let cluster_name: String = map
+        .get("cluster_name")
+        .map(|v| v.as_str())
+        .flatten()
+        .map(ToOwned::to_owned)
+        .expect("/_cluster/health must contain cluster_name");
+
+    for color in COLORS.iter() {
+        if color == &cluster_status {
+            CLUSTER_STATUS
+                .with_label_values(&[&cluster_name, &cluster_status])
+                .set(1);
+        } else {
+            CLUSTER_STATUS
+                .with_label_values(&[&cluster_name, color])
+                .set(0);
+        }
+    }
 }
 
 crate::poll_metrics!();
+
+#[tokio::test]
+async fn test_cluster_health() {
+    let cluster_health: CluserHealthResponse =
+        serde_json::from_str(include_str!("../../tests/files/cluster_health.json"))
+            .expect("valid json");
+
+    let values = cluster_health.into_value(inject_cluster_health);
+
+    let metrics = metric::from_value(values);
+    assert!(!metrics.is_empty());
+
+    let cluster_status_injection = metrics[0].iter().find(|m| m.key() == "cluster_status");
+    assert!(cluster_status_injection.is_some());
+}

--- a/src/metrics/_cluster/mod.rs
+++ b/src/metrics/_cluster/mod.rs
@@ -1,2 +1,4 @@
+mod responses;
+
 pub(crate) mod health;
 pub(crate) mod stats;

--- a/src/metrics/_cluster/responses/mod.rs
+++ b/src/metrics/_cluster/responses/mod.rs
@@ -1,0 +1,15 @@
+use serde_json::{Map, Value};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CluserHealthResponse(Value);
+
+impl CluserHealthResponse {
+    /// Inject labels into nodes response
+    pub(crate) fn into_value(mut self, value_mangle: fn(&mut Map<String, Value>)) -> Value {
+        if let Some(mut map) = self.0.as_object_mut() {
+            value_mangle(&mut map)
+        }
+
+        self.0
+    }
+}

--- a/src/tests/files/cluster_health.json
+++ b/src/tests/files/cluster_health.json
@@ -1,0 +1,17 @@
+{
+  "status": "green",
+  "active_primary_shards": 215,
+  "active_shards": 1140,
+  "active_shards_percent_as_number": 100,
+  "cluster_name": "some",
+  "delayed_unassigned_shards": 0,
+  "initializing_shards": 0,
+  "number_of_data_nodes": 108,
+  "number_of_in_flight_fetch": 0,
+  "number_of_nodes": 135,
+  "number_of_pending_tasks": 0,
+  "relocating_shards": 0,
+  "task_max_waiting_in_queue_millis": 0,
+  "timed_out": false,
+  "unassigned_shards": 0
+}


### PR DESCRIPTION
Although one could easily reason about cluster_health from metrics below having explicitly dedicated metric is way clearer for the user.

Adding metric, whenever status label will change this will be triggered 

```
elasticsearch_cluster_health_status{cluster="some",color="green"} 1
elasticsearch_cluster_health_status{cluster="some",color="red"} 0
elasticsearch_cluster_health_status{cluster="some",color="yellow"} 0
```



```
# HELP elasticsearch_cluster_health_number_of_data_nodes number_of_data_nodes
# TYPE elasticsearch_cluster_health_number_of_data_nodes gauge
elasticsearch_cluster_health_number_of_data_nodes{cluster="some",status="green"} 160
# HELP elasticsearch_cluster_health_number_of_nodes number_of_nodes
# TYPE elasticsearch_cluster_health_number_of_nodes gauge
elasticsearch_cluster_health_number_of_nodes{cluster="some",status="green"} 175
# HELP elasticsearch_cluster_health_timed_out timed_out
# TYPE elasticsearch_cluster_health_timed_out gauge
elasticsearch_cluster_health_timed_out{cluster="some",status="green"} 0
# HELP elasticsearch_subsystem_request_duration_seconds The Elasticsearch subsystem req
```