### PR TITLE
Elasticsearch query fields/make optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Exporter settings:
 elasticsearch_url: http://127.0.0.1:9200
 elasticsearch_global_timeout: 30s
 elasticsearch_query_fields:
- - nodes_stats: *
 elasticsearch_subsystem_timeouts:
  - nodes_stats: 15s
 elasticsearch_path_parameters:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_ur
  - Metric collection is decoupled from serving `/metrics` page
  - Skips zero/empty metrics (controlled with flag `exporter_allow_zero_metrics`)
  - Elasticsearch "millis" converted to seconds
+ - Elasticsearch "kilobytes" converted to bytes
  - All time based metrics are converted as f64 seconds, keywords `millis` replaced with `seconds`
  - Added `_bytes` and `_seconds` postfix
  - Preserves metrics tree namespace up to last leaf

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ exporter_include_labels:
  - cat_transforms: index
  - cluster_health: status
  - nodes_info: name
- - nodes_stats: name,vin_cluster_version
+ - nodes_stats: name
  - nodes_usage: name
  - stats: index
 exporter_skip_metrics:

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -132,7 +132,7 @@ pub struct Opts {
 
     /// Elasticsearch query ?fields= for /_nodes/stats fields comma-separated list or
     /// wildcard expressions of fields to include in the statistics.
-    #[clap(long = "elasticsearch_query_fields", default_value = "nodes_stats=*")]
+    #[clap(long = "elasticsearch_query_fields", default_value = "")]
     pub elasticsearch_query_fields: HashMapVec,
 
     /// Exporter default metrics lifeimte interval in seconds
@@ -213,6 +213,10 @@ impl FromStr for HashMapVec {
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let mut map = CollectionLabels::new();
+
+        if input.is_empty() {
+            return Ok(Self(map));
+        }
 
         let parts = input.trim().split('&').collect::<Vec<&str>>();
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -95,7 +95,7 @@ pub struct Opts {
     /// Exporter include labels
     #[clap(
         long = "exporter_include_labels",
-        default_value = "cat_health=shards&cat_aliases=index,alias&cat_allocation=node&cat_fielddata=node,field&cat_indices=index&cat_nodeattrs=node,attr&cat_nodes=ip,name,node_role&cat_pending_tasks=index&cat_plugins=name&cat_recovery=index,shard,stage,type&cat_repositories=index&cat_segments=index,shard&cat_shards=index,node,shard&cat_templates=name,index_patterns&cat_thread_pool=node_name,name,type&cat_transforms=index&cluster_health=status&nodes_usage=name&nodes_stats=name,vin_cluster_version&nodes_info=name&stats=index"
+        default_value = "cat_health=shards&cat_aliases=index,alias&cat_allocation=node&cat_fielddata=node,field&cat_indices=index&cat_nodeattrs=node,attr&cat_nodes=ip,name,node_role&cat_pending_tasks=index&cat_plugins=name&cat_recovery=index,shard,stage,type&cat_repositories=index&cat_segments=index,shard&cat_shards=index,node,shard&cat_templates=name,index_patterns&cat_thread_pool=node_name,name,type&cat_transforms=index&cluster_health=status&nodes_usage=name&nodes_stats=name&nodes_info=name&stats=index"
     )]
     pub exporter_include_labels: HashMapVec,
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -216,65 +216,50 @@ impl Collection {
         for metric in metrics.into_iter() {
             trace!("Collection metric: {:?}", metric);
 
+            let key = metric.key();
+
             match metric.metric_type() {
                 MetricType::Switch(value) => {
-                    if let Err(e) =
-                        self.insert_gauge(metric.key(), *value as i64, &labels, None, false, now)
+                    if let Err(e) = self.insert_gauge(key, *value as i64, &labels, None, false, now)
                     {
                         error!("SWITCH insert_gauge {:?} err {}", metric, e);
                         return Err(e);
                     }
                 }
                 MetricType::Bytes(value) => {
-                    let adjusted_key = metric.key().replace("_kilobytes", "_bytes");
-
                     // /_cat/recovery has key name `bytes`
-                    let postfix = if adjusted_key.ends_with("bytes") {
+                    let postfix = if key.ends_with("bytes") {
                         None
                     } else {
                         Some("_bytes")
                     };
-
-                    if let Err(e) =
-                        self.insert_gauge(&adjusted_key, *value, &labels, postfix, true, now)
-                    {
+                    if let Err(e) = self.insert_gauge(key, *value, &labels, postfix, true, now) {
                         error!("BYTES insert_gauge {:?} err {}", metric, e);
                         return Err(e);
                     }
                 }
                 MetricType::GaugeF(value) => {
-                    if let Err(e) =
-                        self.insert_fgauge(metric.key(), *value, &labels, None, true, now)
-                    {
+                    if let Err(e) = self.insert_fgauge(key, *value, &labels, None, true, now) {
                         error!("GAUGEF insert_fgauge {:?} err {}", metric, e);
                         return Err(e);
                     }
                 }
                 MetricType::Gauge(value) => {
-                    if let Err(e) =
-                        self.insert_gauge(metric.key(), *value, &labels, None, true, now)
-                    {
+                    if let Err(e) = self.insert_gauge(key, *value, &labels, None, true, now) {
                         error!("GAUGE insert_gauge {:?} err {}", metric, e);
                         return Err(e);
                     }
                 }
                 MetricType::Time(duration) => {
-                    let adjusted_key = metric.key().replace("_millis", "_seconds");
-
-                    let postfix = if adjusted_key.ends_with("_seconds") {
+                    let postfix = if key.ends_with("_seconds") {
                         None
                     } else {
                         Some("_seconds")
                     };
 
-                    if let Err(e) = self.insert_fgauge(
-                        &adjusted_key,
-                        duration.as_secs_f64(),
-                        &labels,
-                        postfix,
-                        true,
-                        now,
-                    ) {
+                    if let Err(e) =
+                        self.insert_fgauge(key, duration.as_secs_f64(), &labels, postfix, true, now)
+                    {
                         error!("TIME insert_fgauge {:?} err {}", metric, e);
                         return Err(e);
                     }

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -226,14 +226,17 @@ impl Collection {
                     }
                 }
                 MetricType::Bytes(value) => {
+                    let adjusted_key = metric.key().replace("_kilobytes", "_bytes");
+
                     // /_cat/recovery has key name `bytes`
-                    let postfix = if metric.key().ends_with("bytes") {
+                    let postfix = if adjusted_key.ends_with("bytes") {
                         None
                     } else {
                         Some("_bytes")
                     };
+
                     if let Err(e) =
-                        self.insert_gauge(metric.key(), *value, &labels, postfix, true, now)
+                        self.insert_gauge(&adjusted_key, *value, &labels, postfix, true, now)
                     {
                         error!("BYTES insert_gauge {:?} err {}", metric, e);
                         return Err(e);

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -40,7 +40,7 @@ impl<'s> TryFrom<RawMetric<'s>> for Metric {
     type Error = MetricError;
 
     fn try_from(metric: RawMetric) -> Result<Self, MetricError> {
-        let key: String = metric.0.replace(".", "_");
+        let mut key: String = metric.0.replace(".", "_");
 
         let underscore_index = key.rfind('_').unwrap_or(0);
 
@@ -54,6 +54,10 @@ impl<'s> TryFrom<RawMetric<'s>> for Metric {
         debug_assert!(!last.contains('.'));
 
         let metric_type = MetricType::try_from((last, metric.1))?;
+
+        key = key
+            .replace("_kilobytes", "_bytes")
+            .replace("_millis", "_seconds");
 
         Ok(Self(key, metric_type))
     }

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -11,7 +11,7 @@ pub(crate) type RawMetric<'s> = (&'s str, &'s Value);
 
 /// Metric consisting of Key and parsed metric type
 #[derive(Debug, PartialEq)]
-pub struct Metric(String, MetricType);
+pub struct Metric(pub(crate) String, pub(crate) MetricType);
 
 /// Vector of metrics for convenience
 pub type Metrics = Vec<Metric>;

--- a/src/metrics/_nodes/stats.rs
+++ b/src/metrics/_nodes/stats.rs
@@ -45,45 +45,111 @@ const REMOVE_KEYS: &[&str] = &[
 
 crate::poll_metrics!();
 
-#[tokio::test]
-async fn test_nodes_stats() {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{
+        metadata::node_data::{NodeData, NodeDataMap},
+        metric::{Metric, MetricType},
+    };
     use tokio::sync::RwLock;
 
-    use crate::metadata::node_data::{NodeData, NodeDataMap};
+    #[tokio::test]
+    async fn test_nodes_stats() {
+        let stats: NodesResponse =
+            serde_json::from_str(include_str!("../../tests/files/nodes_stats.json"))
+                .expect("valid json");
 
-    let stats: NodesResponse =
-        serde_json::from_str(include_str!("../../tests/files/nodes_stats.json"))
-            .expect("valid json");
+        let expected_name: String = "m1-nodename.example.com".into();
 
-    let expected_name: String = "m1-nodename.example.com".into();
+        let mut metadata = NodeDataMap::new();
+        let _ = metadata.insert(
+            "U-WnGaTpRxucgde3miiDWw".into(),
+            NodeData {
+                name: expected_name.clone(),
+                ..Default::default()
+            },
+        );
+        let metadata = RwLock::new(metadata);
 
-    let mut metadata = NodeDataMap::new();
-    let _ = metadata.insert(
-        "U-WnGaTpRxucgde3miiDWw".into(),
-        NodeData {
-            name: expected_name.clone(),
-            ..Default::default()
-        },
-    );
-    let metadata = RwLock::new(metadata);
+        let values = stats.into_values(&metadata, &["timestamp"]).await;
+        assert!(!values.is_empty());
+        // When keys to remove: "timestamp"
+        assert!(values[0].get("timestamp").is_none());
 
-    let values = stats.into_values(&metadata, &["timestamp"]).await;
-    assert!(!values.is_empty());
-    // When keys to remove: "timestamp"
-    assert!(values[0].get("timestamp").is_none());
+        let value = values.last().unwrap().as_object().unwrap();
+        assert_eq!(value.get("name").unwrap().as_str().unwrap(), expected_name);
 
-    let value = values.last().unwrap().as_object().unwrap();
-    assert_eq!(value.get("name").unwrap().as_str().unwrap(), expected_name);
+        let stats: NodesResponse =
+            serde_json::from_str(include_str!("../../tests/files/nodes_stats.json"))
+                .expect("valid json");
+        // When keys remove empty
+        let values = stats.into_values(&metadata, &[]).await;
+        assert!(!values.is_empty());
 
-    let stats: NodesResponse =
-        serde_json::from_str(include_str!("../../tests/files/nodes_stats.json"))
-            .expect("valid json");
-    // When keys remove empty
-    let values = stats.into_values(&metadata, &[]).await;
-    assert!(!values.is_empty());
+        let values = values[0].as_object().unwrap();
+        assert_eq!(values.get("name").unwrap().as_str().unwrap(), expected_name);
 
-    let values = values[0].as_object().unwrap();
-    assert_eq!(values.get("name").unwrap().as_str().unwrap(), expected_name);
+        assert!(values.get("timestamp").is_some());
+    }
 
-    assert!(values.get("timestamp").is_some());
+    #[tokio::test]
+    async fn test_nodes_metrics() {
+        let stats: NodesResponse =
+            serde_json::from_str(include_str!("../../tests/files/nodes_stats.json"))
+                .expect("valid json");
+
+        let expected_name: String = "m1-nodename.example.com".into();
+
+        let mut metadata = NodeDataMap::new();
+        let _ = metadata.insert(
+            "U-WnGaTpRxucgde3miiDWw".into(),
+            NodeData {
+                name: expected_name.clone(),
+                ..Default::default()
+            },
+        );
+        let metadata = RwLock::new(metadata);
+        let values = stats.into_values(&metadata, &["timestamp"]).await;
+
+        let metrics = metric::from_values(values);
+
+        let expected = vec![
+            Metric(
+                "fs_io_stats_devices_device_name".into(),
+                MetricType::Label("sda4".into()),
+            ),
+            Metric("ip".into(), MetricType::Label("".into())),
+            Metric("name".into(), MetricType::Label(expected_name.clone())),
+            Metric(
+                "fs_io_stats_devices_operations".into(),
+                MetricType::Gauge(216732278),
+            ),
+            Metric(
+                "fs_io_stats_devices_read_kilobytes".into(),
+                MetricType::Bytes(21143552),
+            ),
+            Metric(
+                "fs_io_stats_devices_read_operations".into(),
+                MetricType::Gauge(1119),
+            ),
+            Metric("vin_cluster_version".into(), MetricType::Label("".into())),
+            Metric(
+                "fs_io_stats_devices_write_kilobytes".into(),
+                MetricType::Bytes(2455948251136),
+            ),
+            Metric(
+                "fs_io_stats_devices_write_operations".into(),
+                MetricType::Gauge(216731159),
+            ),
+        ];
+
+        assert!(
+            metrics.contains(&expected),
+            "got {:?}\nexpected {:?}",
+            metrics,
+            expected
+        );
+    }
 }

--- a/src/metrics/_nodes/stats.rs
+++ b/src/metrics/_nodes/stats.rs
@@ -127,7 +127,7 @@ mod tests {
                 MetricType::Gauge(216732278),
             ),
             Metric(
-                "fs_io_stats_devices_read_kilobytes".into(),
+                "fs_io_stats_devices_read_bytes".into(),
                 MetricType::Bytes(21143552),
             ),
             Metric(
@@ -136,13 +136,32 @@ mod tests {
             ),
             Metric("vin_cluster_version".into(), MetricType::Label("".into())),
             Metric(
-                "fs_io_stats_devices_write_kilobytes".into(),
+                "fs_io_stats_devices_write_bytes".into(),
                 MetricType::Bytes(2455948251136),
             ),
             Metric(
                 "fs_io_stats_devices_write_operations".into(),
                 MetricType::Gauge(216731159),
             ),
+        ];
+
+        assert!(
+            metrics.contains(&expected),
+            "got {:?}\nexpected {:?}",
+            metrics,
+            expected
+        );
+
+        let expected = vec![
+            Metric("ip".into(), MetricType::Label("".into())),
+            Metric("name".into(), MetricType::Label(expected_name.clone())),
+            Metric("indices_flush_periodic".into(), MetricType::Gauge(1286)),
+            Metric("indices_flush_total".into(), MetricType::Gauge(1401)),
+            Metric(
+                "indices_flush_total_time_in_seconds".into(),
+                MetricType::Time(Duration::from_millis(7333176)),
+            ),
+            Metric("vin_cluster_version".into(), MetricType::Label("".into())),
         ];
 
         assert!(


### PR DESCRIPTION
- Make elasticsearch_query_fields optional
- convert kilobytes to bytes
- contain key adjusting from _kilobytes to _bytes and _millis to _seconds