### PR TITLE
metric_type: add support for additional labels

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -95,7 +95,7 @@ pub struct Opts {
     /// Exporter include labels
     #[clap(
         long = "exporter_include_labels",
-        default_value = "cat_health=shards&cat_aliases=index,alias&cat_allocation=node&cat_fielddata=node,field&cat_indices=index&cat_nodeattrs=node,attr&cat_nodes=ip,name,node_role&cat_pending_tasks=index&cat_plugins=name&cat_recovery=index,shard,stage,type&cat_repositories=index&cat_segments=index,shard&cat_shards=index,node,shard&cat_templates=name,index_patterns&cat_thread_pool=node_name,name,type&cat_transforms=index&cluster_health=status&nodes_usage=name&nodes_stats=name&nodes_info=name&stats=index"
+        default_value = "cat_health=shards&cat_aliases=index,alias&cat_allocation=node&cat_fielddata=node,field&cat_indices=index&cat_nodeattrs=node,attr&cat_nodes=ip,name,node_role&cat_pending_tasks=index,insertorder,timeinqueue,priority,source&cat_plugins=name&cat_recovery=index,shard,stage,type&cat_repositories=index&cat_segments=index,shard&cat_shards=index,node,shard&cat_templates=name,index_patterns&cat_thread_pool=node_name,name,type&cat_transforms=index&cluster_health=status&nodes_usage=name&nodes_stats=name&nodes_info=name&stats=index"
     )]
     pub exporter_include_labels: HashMapVec,
 

--- a/src/metric/metric_type.rs
+++ b/src/metric/metric_type.rs
@@ -191,7 +191,7 @@ impl<'s> TryFrom<RawMetric<'s>> for MetricType {
             | "health" | "build" | "node" | "state" | "patterns" | "of" | "segment" | "host"
             | "ip" | "prirep" | "id" | "status" | "at" | "for" | "details" | "reason" | "port"
             | "attr" | "field" | "shard" | "index" | "name" | "type" | "version"
-            | "description" => Ok(MetricType::Label(
+            | "description" | "agent" | "uri" => Ok(MetricType::Label(
                 value.as_str().ok_or_else(unknown)?.to_owned(),
             )),
             _ => {


### PR DESCRIPTION
Add additional labels: agent and uri from /_nodes/stats 