### PR TITLE
metric: add name normalization on brackets and slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ $ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_ur
    - IP namespaced -> `ip`
  - Automatic metrics deletion based on lifetime settings, by default metric by value will be
    deleted after 600s since last occurrence.
+ - Metric names are normalized to snake case, colon is replaced with underscore, brackets are replaced with colon (:)
+   - "transport_actions_cluster:monitor/nodes/info[n]_requests_count" -> "transport_actions_cluster_monitor_nodes_info:n:_requests_count"
+   - "transport_actions_internal:cluster/coordination/join/ping_requests_count" -> "transport_actions_internal_cluster_coordination_join_ping_requests_count"
 
 ## Options
 


### PR DESCRIPTION
Adding metrics normalization when key contains brackets, slashes and colons.
Colon will get normalized into 


Sample.

```
"transport_actions_cluster:monitor/nodes/info[n]_requests_count"
"transport_actions_cluster:monitor/nodes/info[n]_requests_histogram_count"
"transport_actions_cluster:monitor/nodes/info[n]_responses_count"
"transport_actions_cluster:monitor/nodes/info[n]_responses_histogram_count"
"transport_actions_cluster:monitor/nodes/info[n]_responses_histogram_ge_bytes"
"transport_actions_cluster:monitor/nodes/stats[n]_requests_count"
"transport_actions_cluster:monitor/nodes/stats[n]_requests_histogram_count"
"transport_actions_cluster:monitor/nodes/stats[n]_responses_count"
"transport_actions_cluster:monitor/nodes/stats[n]_responses_histogram_count"
"transport_actions_cluster:monitor/nodes/usage[n]_requests_count"
"transport_actions_cluster:monitor/nodes/usage[n]_requests_histogram_count"
"transport_actions_cluster:monitor/nodes/usage[n]_responses_count"
"transport_actions_cluster:monitor/nodes/usage[n]_responses_histogram_count"
"transport_actions_indices:admin/seq_no/retention_lease_background_sync[r]_requests_count"
"transport_actions_indices:admin/seq_no/retention_lease_background_sync[r]_requests_histogram_count"
"transport_actions_indices:admin/seq_no/retention_lease_background_sync[r]_responses_count"
"transport_actions_indices:admin/seq_no/retention_lease_background_sync[r]_responses_histogram_count"
"transport_actions_indices:monitor/recovery[n]_requests_count"
"transport_actions_indices:monitor/recovery[n]_requests_histogram_count"
"transport_actions_indices:monitor/recovery[n]_responses_count"
"transport_actions_indices:monitor/recovery[n]_responses_histogram_count"
"transport_actions_indices:monitor/segments[n]_requests_count"
"transport_actions_indices:monitor/segments[n]_requests_histogram_count"
"transport_actions_indices:monitor/segments[n]_responses_count"
"transport_actions_indices:monitor/segments[n]_responses_histogram_count"
"transport_actions_indices:monitor/segments[n]_responses_histogram_ge_bytes"
"transport_actions_indices:monitor/stats[n]_requests_count"
"transport_actions_indices:monitor/stats[n]_requests_histogram_count"
"transport_actions_indices:monitor/stats[n]_responses_count"
"transport_actions_indices:monitor/stats[n]_responses_histogram_count"
"transport_actions_internal:cluster/coordination/commit_state_requests_count"
"transport_actions_internal:cluster/coordination/commit_state_requests_histogram_count"
"transport_actions_internal:cluster/coordination/commit_state_responses_count"
"transport_actions_internal:cluster/coordination/commit_state_responses_histogram_count"
"transport_actions_internal:cluster/coordination/join/ping_requests_count"
"transport_actions_internal:cluster/coordination/join/ping_requests_histogram_count"
"transport_actions_internal:cluster/coordination/join/ping_responses_count"
"transport_actions_internal:cluster/coordination/join/ping_responses_histogram_count"
"transport_actions_internal:cluster/coordination/join/validate_requests_count"
"transport_actions_internal:cluster/coordination/join/validate_requests_histogram_count"
"transport_actions_internal:cluster/coordination/join/validate_responses_count"
"transport_actions_internal:cluster/coordination/join/validate_responses_histogram_count"
"transport_actions_internal:cluster/coordination/publish_state_requests_count"
"transport_actions_internal:cluster/coordination/publish_state_requests_histogram_count"
"transport_actions_internal:cluster/coordination/publish_state_requests_histogram_ge_bytes"
"transport_actions_internal:cluster/coordination/publish_state_responses_count"
"transport_actions_internal:cluster/coordination/publish_state_responses_histogram_count"
"transport_actions_internal:cluster/nodes/indices/shard/store[n]_requests_count"
"transport_actions_internal:cluster/nodes/indices/shard/store[n]_requests_histogram_count"
"transport_actions_internal:cluster/nodes/indices/shard/store[n]_responses_count"
"transport_actions_internal:cluster/nodes/indices/shard/store[n]_responses_histogram_count"
"transport_actions_internal:coordination/fault_detection/follower_check_requests_count"
"transport_actions_internal:coordination/fault_detection/follower_check_requests_histogram_count"
"transport_actions_internal:coordination/fault_detection/follower_check_responses_count"
"transport_actions_internal:coordination/fault_detection/follower_check_responses_histogram_count"
"transport_actions_internal:index/shard/recovery/file_chunk_requests_count"
"transport_actions_internal:index/shard/recovery/file_chunk_requests_histogram_count"
"transport_actions_internal:index/shard/recovery/file_chunk_responses_count"
"transport_actions_internal:index/shard/recovery/file_chunk_responses_histogram_count"
"transport_actions_internal:index/shard/recovery/filesInfo_requests_count"
"transport_actions_internal:index/shard/recovery/filesInfo_requests_histogram_count"
"transport_actions_internal:index/shard/recovery/filesInfo_responses_count"
"transport_actions_internal:index/shard/recovery/filesInfo_responses_histogram_count"
"transport_actions_internal:index/shard/recovery/finalize_requests_count"
"transport_actions_internal:index/shard/recovery/finalize_requests_histogram_count"
"transport_actions_internal:index/shard/recovery/finalize_responses_count"
"transport_actions_internal:index/shard/recovery/finalize_responses_histogram_count"
"transport_actions_internal:index/shard/recovery/prepare_translog_requests_count"
"transport_actions_internal:index/shard/recovery/prepare_translog_requests_histogram_count"
```