### PR TITLE
allow using filter_path for /stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Scraping `/_nodes/stats` subsystem thread_pool + fs paths metric
 $ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_url=http://IP:PORT --exporter_metrics_enabled="nodes_stats=true" --elasticsearch_path_parameters="nodes_stats=thread_pool,fs"
 ```
 
+Scraping `/stats` for `total.indexing` and `total.search` metrics only
+
+```
+$ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_url=http://IP:PORT --exporter_metrics_enabled="stats=true" --elasticsearch_query_filter_path="stats=indices.*.total.indexing,indices.*.total.search" 
+```
 
 ```shell
 $ curl -s http://127.0.0.1:9222

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -135,6 +135,11 @@ pub struct Opts {
     #[clap(long = "elasticsearch_query_fields", default_value = "")]
     pub elasticsearch_query_fields: HashMapVec,
 
+    /// Elasticsearch query ?filter_path= for /stats. Comma-separated list or
+    /// wildcard expressions of paths to include in the statistics.
+    #[clap(long = "elasticsearch_query_filter_path", default_value = "")]
+    pub elasticsearch_query_filter_path: HashMapVec,
+
     /// Exporter default metrics lifeimte interval in seconds
     #[clap(
         long = "exporter_metrics_lifetime_default_interval",

--- a/src/bin/elasticsearch_exporter.rs
+++ b/src/bin/elasticsearch_exporter.rs
@@ -99,6 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         elasticsearch_url: opts.elasticsearch_url.clone(),
         elasticsearch_global_timeout: *opts.elasticsearch_global_timeout,
         elasticsearch_query_fields: opts.elasticsearch_query_fields.0.clone(),
+        elasticsearch_query_filter_path: opts.elasticsearch_query_filter_path.0.clone(),
         elasticsearch_subsystem_timeouts: opts.elasticsearch_subsystem_timeouts.0.clone(),
         elasticsearch_path_parameters: opts.elasticsearch_path_parameters.0.clone(),
 

--- a/src/metrics/_stats/_all.rs
+++ b/src/metrics/_stats/_all.rs
@@ -6,6 +6,7 @@ pub(crate) const SUBSYSTEM: &str = "stats";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
     let fields = exporter.options().query_fields_for_subsystem(SUBSYSTEM);
+    let filter_path = exporter.options().query_filter_path_for_subsystem(SUBSYSTEM);
 
     let indices = exporter.client().indices();
 
@@ -15,6 +16,10 @@ async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Err
 
     if !fields.is_empty() {
         indices_stats = indices_stats.fields(&fields);
+    }
+
+    if !filter_path.is_empty() {
+        indices_stats = indices_stats.filter_path(&filter_path)
     }
 
     let response = indices_stats.send().await?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -14,6 +14,9 @@ pub struct ExporterOptions {
     /// Elasticsearch /_nodes/stats fields comma-separated list or
     /// wildcard expressions of fields to include in the statistics.
     pub elasticsearch_query_fields: CollectionLabels,
+    /// Elasticsearch /stats filter_path. Comma-separated list or
+    /// wildcard expressions of paths to include in the statistics.
+    pub elasticsearch_query_filter_path: CollectionLabels,
     /// Exporter timeout for subsystems, in case subsystem timeout is not defined
     /// default global timeout is used
     pub elasticsearch_subsystem_timeouts: ExporterPollIntervals,
@@ -66,6 +69,14 @@ impl ExporterOptions {
     /// ?fields= parameters for subsystems
     pub fn query_fields_for_subsystem(&self, subsystem: &'static str) -> Vec<&str> {
         self.elasticsearch_query_fields
+            .get(subsystem)
+            .map(|params| params.iter().map(AsRef::as_ref).collect::<Vec<&str>>())
+            .unwrap_or_default()
+    }
+
+    /// ?filter_path= parameters for subsystems
+    pub fn query_filter_path_for_subsystem(&self, subsystem: &'static str) -> Vec<&str> {
+        self.elasticsearch_query_filter_path
             .get(subsystem)
             .map(|params| params.iter().map(AsRef::as_ref).collect::<Vec<&str>>())
             .unwrap_or_default()
@@ -218,6 +229,12 @@ impl fmt::Display for ExporterOptions {
             &mut output,
             "elasticsearch_query_fields",
             &self.elasticsearch_query_fields,
+        );
+
+        collection_labels_to_string(
+            &mut output,
+            "elasticsearch_query_filter_path",
+            &self.elasticsearch_query_filter_path,
         );
 
         poll_duration_to_string(


### PR DESCRIPTION
`filter_path` allows to limit what data is returned from /stats.