### PR TITLE
allow using filter_path for /_cat/shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Scraping `/stats` for `total.indexing` and `total.search` metrics only
 $ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_url=http://IP:PORT --exporter_metrics_enabled="stats=true" --elasticsearch_query_filter_path="stats=indices.*.total.indexing,indices.*.total.search" 
 ```
 
+Scraping `/_cat/shards` for `search.fetch*` metrics only. In this case `elasticsearch_query_filter_path` must always include `index,shard`, and dotted format is not supported. Example: 
+
+```
+$ docker run --network=host -it vinted/elasticsearch_exporter --elasticsearch_url=http://IP:PORT --exporter_metrics_enabled="cat_shards=true" --elasticsearch_query_filter_path="cat_shards=index,shard,search*fetch*" 
+```
+
 ```shell
 $ curl -s http://127.0.0.1:9222
 Vinted Elasticsearch exporter

--- a/src/metrics/_cat/shards.rs
+++ b/src/metrics/_cat/shards.rs
@@ -6,17 +6,23 @@ use super::responses::CatResponse;
 pub(crate) const SUBSYSTEM: &str = "cat_shards";
 
 async fn metrics(exporter: &Exporter) -> Result<Vec<Metrics>, elasticsearch::Error> {
-    let response = exporter
-        .client()
-        .cat()
+    let filter_path = exporter.options().query_filter_path_for_subsystem(SUBSYSTEM);
+
+    let cat = exporter.client().cat();
+
+    let mut shards_stats = cat
         .shards(CatShardsParts::Index(&["*"]))
         .format("json")
         .h(&["*"])
         .bytes(Bytes::B)
         .request_timeout(exporter.options().timeout_for_subsystem(SUBSYSTEM))
-        .time(Time::Ms)
-        .send()
-        .await?;
+        .time(Time::Ms);
+
+    if !filter_path.is_empty() {
+        shards_stats = shards_stats.filter_path(&filter_path)
+    }
+
+    let response = shards_stats.send().await?;
 
     let values = response.json::<CatResponse>().await?.into_values(|map| {
         if map


### PR DESCRIPTION
Allow filtering what is returned from /_cat/shards.

Raw example:

```
http://es:9200/_cat/shards?h=*&format=json&filter_path=index,shard,search*fetch*

[
        {
		"index": "blogs",
		"shard": "0",
		"search.fetch_current": "0",
		"search.fetch_time": "3ms",
		"search.fetch_total": "6"
	},
	{
        ...
```

Also returns faster with filtering:
```
Without filtering:
elasticsearch_subsystem_request_duration_seconds_sum{cluster="logs4",subsystem="/cat_shards"} 77.776766292
elasticsearch_subsystem_request_duration_seconds_count{cluster="logs4",subsystem="/cat_shards"} 2

With filtering:
elasticsearch_subsystem_request_duration_seconds_sum{cluster="logs4",subsystem="/cat_shards"} 9.690492667000001
elasticsearch_subsystem_request_duration_seconds_count{cluster="logs4",subsystem="/cat_shards"} 3
```